### PR TITLE
Support adding user keys

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -11,6 +11,7 @@ func Server() http.Handler {
 	mux := httprouter.New()
 	mux.GET("/status", HealthCheck)
 	mux.POST("/users", RegisterUser)
+	mux.POST("/users/:user_id/api-keys", AddUserKey)
 
 	n := negroni.Classic()
 	n.UseHandler(mux)

--- a/api/users.go
+++ b/api/users.go
@@ -2,8 +2,10 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 
 	"github.com/julienschmidt/httprouter"
 	"github.com/mainflux/mainflux-auth-server/domain"
@@ -18,7 +20,8 @@ type userReq struct {
 func RegisterUser(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		panic(err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
 	}
 
 	data := &userReq{}
@@ -29,12 +32,58 @@ func RegisterUser(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 
 	user, err := services.RegisterUser(data.Username, data.Password)
 	if err != nil {
-		authErr := err.(*domain.AuthError)
-		w.WriteHeader(authErr.Code)
+		serviceErr := err.(*domain.ServiceError)
+		w.WriteHeader(serviceErr.Code)
 		return
 	}
 
 	w.WriteHeader(http.StatusCreated)
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(user)
+}
+
+func AddUserKey(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	header := strings.Split(r.Header.Get("Authorization"), " ")
+	if len(header) != 2 {
+		w.WriteHeader(http.StatusForbidden)
+		return
+	}
+
+	apiKey := header[1]
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	data := domain.Payload{}
+	if err := json.Unmarshal(body, &data); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if len(data.Scopes) == 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	for _, s := range data.Scopes {
+		if s.Actions == "" || s.Id == "" || s.Resource == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+	}
+
+	uid := ps.ByName("user_id")
+	key, err := services.AddUserKey(uid, apiKey, data)
+	if err != nil {
+		serviceErr := err.(*domain.ServiceError)
+		w.WriteHeader(serviceErr.Code)
+		return
+	}
+
+	rep := fmt.Sprintf(`{"key":"%s"}`, key)
+	w.WriteHeader(http.StatusCreated)
+	w.Header().Set("Content-Type", "application/json")
+	w.Write([]byte(rep))
 }

--- a/api/users_test.go
+++ b/api/users_test.go
@@ -6,13 +6,15 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/garyburd/redigo/redis"
 	"github.com/mainflux/mainflux-auth-server/api"
+	"github.com/mainflux/mainflux-auth-server/cache"
 )
 
 func TestRegisterUser(t *testing.T) {
 	cases := []struct {
-		in  string
-		out int
+		body string
+		code int
 	}{
 		{`{"username":"test","password":"test"}`, 201},
 		{"1", 400},
@@ -27,15 +29,91 @@ func TestRegisterUser(t *testing.T) {
 	url := ts.URL + "/users"
 
 	for _, c := range cases {
-		b := strings.NewReader(c.in)
+		b := strings.NewReader(c.body)
 
 		res, err := http.Post(url, "application/json", b)
 		if err != nil {
 			t.Error("cannot make a request:", err)
 		}
 
-		if res.StatusCode != c.out {
-			t.Errorf("expected status %d got %d", c.out, res.StatusCode)
+		if res.StatusCode != c.code {
+			t.Errorf("expected status %d got %d", c.code, res.StatusCode)
 		}
 	}
+}
+
+func TestAddUserKey(t *testing.T) {
+	uid, masterKey, err := fetchCredentials()
+	if err != nil {
+		t.Error("failed to retrieve created user data")
+	}
+
+	cases := []struct {
+		header string
+		path   string
+		body   string
+		code   int
+	}{
+		{masterKey, uid, `{"scopes":[{"actions":"RW","resource":"*","id":"*"}]}`, 201},
+		{masterKey, uid, "1", 400},
+		{masterKey, uid, `{"scopes":[]}`, 400},
+		{masterKey, uid, `{"scopes":[{"actions":""}]}`, 400},
+		{"bad-key", uid, `{"scopes":[{"actions":"RW","resource":"*","id":"*"}]}`, 403},
+		{"", uid, `{"scopes":[{"actions":"RW","resource":"*","id":"*"}]}`, 403},
+		{masterKey, "", `{"scopes":[{"actions":"RW","resource":"*","id":"*"}]}`, 404},
+		{masterKey, "bad-id", `{"scopes":[{"actions":"RW","resource":"*","id":"*"}]}`, 404},
+	}
+
+	ts := httptest.NewServer(api.Server())
+	defer ts.Close()
+
+	for _, c := range cases {
+		url := ts.URL + "/users/" + c.path + "/api-keys"
+		b := strings.NewReader(c.body)
+
+		req, _ := http.NewRequest("POST", url, b)
+		req.Header.Set("Authorization", "Bearer "+c.header)
+		req.Header.Set("Content-Type", "application/json")
+
+		cli := &http.Client{}
+		res, err := cli.Do(req)
+		if err != nil {
+			t.Error("cannot make a request:", err)
+		}
+
+		if res.StatusCode != c.code {
+			t.Errorf("expected status %d got %d", c.code, res.StatusCode)
+		}
+	}
+}
+
+//
+// NOTE: only one user will be created during the test container lifecycle
+//
+func fetchCredentials() (string, string, error) {
+	c := cache.Connection()
+	vals, err := c.Do("KEYS", "users:*")
+	if err != nil {
+		return "", "", err
+	}
+
+	cKeys, err := redis.Strings(vals, err)
+	if err != nil {
+		return "", "", err
+	}
+
+	cKey := cKeys[0]
+	id := strings.Split(cKey, ":")[1]
+
+	cVal, err := c.Do("HGET", cKey, "masterKey")
+	if err != nil {
+		return "", "", err
+	}
+
+	token, err := redis.String(cVal, err)
+	if err != nil {
+		return "", "", err
+	}
+
+	return id, token, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/BurntSushi/toml"
@@ -16,7 +15,7 @@ type Config struct {
 
 func (cfg *Config) Load(file string) {
 	if _, err := toml.DecodeFile(file, &cfg); err != nil {
-		log.Fatalf("Cannot load config due to %s", err)
+		fmt.Printf("Cannot load config due to %s", err)
 		os.Exit(1)
 	}
 }

--- a/domain/errors.go
+++ b/domain/errors.go
@@ -2,12 +2,12 @@ package domain
 
 import "fmt"
 
-type AuthError struct {
+type ServiceError struct {
 	Code    int
 	Message string
 }
 
-func (e *AuthError) Error() string {
+func (e *ServiceError) Error() string {
 	if e == nil {
 		return "<nil>"
 	}

--- a/domain/jwt.go
+++ b/domain/jwt.go
@@ -9,18 +9,18 @@ import (
 const issuer string = "mainflux"
 
 // default key value
-var key string = "mainflux-api-key"
+var secretKey string = "mainflux-api-key"
 
 type tokenClaims struct {
 	Payload
 	jwt.StandardClaims
 }
 
-func SetKey(newKey string) {
-	key = newKey
+func SetSecretKey(key string) {
+	secretKey = key
 }
 
-func CreateToken(subject string, payload *Payload) (string, error) {
+func CreateKey(subject string, payload *Payload) (string, error) {
 	claims := tokenClaims{
 		*payload,
 		jwt.StandardClaims{
@@ -29,8 +29,8 @@ func CreateToken(subject string, payload *Payload) (string, error) {
 		},
 	}
 
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	raw, err := token.SignedString([]byte(key))
+	key := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	raw, err := key.SignedString([]byte(secretKey))
 	if err != nil {
 		return "", err
 	}
@@ -38,14 +38,14 @@ func CreateToken(subject string, payload *Payload) (string, error) {
 	return raw, nil
 }
 
-func ScopesOf(rawToken string) (Payload, error) {
+func ScopesOf(key string) (Payload, error) {
 	var payload Payload
 
 	token, err := jwt.ParseWithClaims(
-		rawToken,
+		key,
 		&tokenClaims{},
 		func(val *jwt.Token) (interface{}, error) {
-			return []byte(key), nil
+			return []byte(secretKey), nil
 		},
 	)
 

--- a/domain/jwt_test.go
+++ b/domain/jwt_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/mainflux/mainflux-auth-server/domain"
 )
 
-const token string = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzY29wZXMiOlt7ImFjdGlvbnMiOiJSIiwicmVzb3VyY2UiOiJjaGFubmVsIiwiaWQiOiJ0ZXN0LWlkIn1dLCJpc3MiOiJtYWluZmx1eCIsInN1YiI6InRlc3QtaWQifQ.QaAdnzbG17SVNb870sj0XKHhO8rPSu_xEvXbeb9PEp4"
+const key string = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzY29wZXMiOlt7ImFjdGlvbnMiOiJSIiwicmVzb3VyY2UiOiJjaGFubmVsIiwiaWQiOiJ0ZXN0LWlkIn1dLCJpc3MiOiJtYWluZmx1eCIsInN1YiI6InRlc3QtaWQifQ.QaAdnzbG17SVNb870sj0XKHhO8rPSu_xEvXbeb9PEp4"
 
 var payload = domain.Payload{
 	[]domain.Scope{
@@ -18,20 +18,20 @@ var payload = domain.Payload{
 	},
 }
 
-func TestCreateToken(t *testing.T) {
+func TestCreateKey(t *testing.T) {
 	subject := "test-id"
-	actual, err := domain.CreateToken(subject, &payload)
+	actual, err := domain.CreateKey(subject, &payload)
 	if err != nil {
 		t.Error("failed to create JWT:", err)
 	}
 
-	if actual != token {
-		t.Errorf("expected %s got %s", token, actual)
+	if actual != key {
+		t.Errorf("expected %s got %s", key, actual)
 	}
 }
 
 func TestScopesOf(t *testing.T) {
-	actual, err := domain.ScopesOf(token)
+	actual, err := domain.ScopesOf(key)
 	if err != nil {
 		t.Error("failed to extract scopes:", err)
 	}

--- a/domain/users.go
+++ b/domain/users.go
@@ -22,7 +22,7 @@ func CreateUser(username, password string) (User, error) {
 
 	p, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {
-		return user, &AuthError{Code: http.StatusInternalServerError}
+		return user, &ServiceError{Code: http.StatusInternalServerError}
 	}
 
 	user.Password = string(p)
@@ -31,9 +31,9 @@ func CreateUser(username, password string) (User, error) {
 	masterScope := Scope{"RWX", "*", "*"}
 	payload := Payload{Scopes: []Scope{masterScope}}
 
-	user.MasterKey, err = CreateToken(user.Id, &payload)
+	user.MasterKey, err = CreateKey(user.Id, &payload)
 	if err != nil {
-		return user, &AuthError{Code: http.StatusInternalServerError}
+		return user, &ServiceError{Code: http.StatusInternalServerError}
 	}
 
 	return user, nil

--- a/domain/users_test.go
+++ b/domain/users_test.go
@@ -23,9 +23,9 @@ func TestCreateUser(t *testing.T) {
 	for _, c := range cases {
 		user, err := domain.CreateUser(c.username, c.username)
 		if err != nil {
-			_, ok := err.(*domain.AuthError)
+			_, ok := err.(*domain.ServiceError)
 			if !ok {
-				t.Errorf("all errors must be AuthError")
+				t.Errorf("all errors must be ServiceError")
 			}
 		}
 

--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ func main() {
 	cfg.Load(opts.Config)
 
 	if cfg.SecretKey != "" {
-		domain.SetKey(cfg.SecretKey)
+		domain.SetSecretKey(cfg.SecretKey)
 	}
 
 	cache.Start(cfg.CacheURL())

--- a/services/users.go
+++ b/services/users.go
@@ -1,28 +1,31 @@
 package services
 
 import (
+	"fmt"
 	"net/http"
 
+	"github.com/garyburd/redigo/redis"
 	"github.com/mainflux/mainflux-auth-server/cache"
 	"github.com/mainflux/mainflux-auth-server/domain"
 )
 
 func RegisterUser(username, password string) (domain.User, error) {
 	var user domain.User
+
 	if username == "" || password == "" {
-		return user, &domain.AuthError{Code: http.StatusBadRequest}
+		return user, &domain.ServiceError{Code: http.StatusBadRequest}
 	}
 
 	c := cache.Connection()
 	defer c.Close()
 
-	n, err := c.Do("SADD", "users", username)
+	cVal, err := redis.Int64(c.Do("SADD", "users", username))
 	if err != nil {
-		return user, &domain.AuthError{Code: http.StatusInternalServerError}
+		return user, &domain.ServiceError{Code: http.StatusInternalServerError}
 	}
 
-	if n.(int64) == 0 {
-		return user, &domain.AuthError{Code: http.StatusConflict}
+	if cVal == 0 {
+		return user, &domain.ServiceError{Code: http.StatusConflict}
 	}
 
 	user, err = domain.CreateUser(username, password)
@@ -33,11 +36,41 @@ func RegisterUser(username, password string) (domain.User, error) {
 	//
 	// NOTE: consider using MULTI to ensure consistency
 	//
-	key := "users:" + user.Username
-	_, err = c.Do("HMSET", key, "id", user.Id, "password", user.Password, "key", user.MasterKey)
+	cKey := "users:" + user.Username
+	_, err = c.Do("HMSET", cKey, "id", user.Id, "password", user.Password, "masterKey", user.MasterKey)
 	if err != nil {
-		return user, &domain.AuthError{Code: http.StatusInternalServerError}
+		return user, &domain.ServiceError{Code: http.StatusInternalServerError}
 	}
 
 	return user, nil
+}
+
+func AddUserKey(uid, key string, payload domain.Payload) (string, error) {
+	c := cache.Connection()
+	defer c.Close()
+
+	cKey := "users:" + uid
+	masterKey, _ := redis.String(c.Do("HGET", cKey, "masterKey"))
+
+	if masterKey == "" {
+		fmt.Println("JEBITE SE FUDBALEEERIIIIII")
+		return "", &domain.ServiceError{Code: http.StatusNotFound}
+	}
+
+	if key != masterKey {
+		return "", &domain.ServiceError{Code: http.StatusForbidden}
+	}
+
+	newKey, err := domain.CreateKey(uid, &payload)
+	if err != nil {
+		return "", &domain.ServiceError{Code: http.StatusInternalServerError}
+	}
+
+	cKey = cKey + ":keys"
+	_, err = c.Do("SADD", cKey, newKey)
+	if err != nil {
+		return "", &domain.ServiceError{Code: http.StatusInternalServerError}
+	}
+
+	return newKey, nil
 }

--- a/services/users_test.go
+++ b/services/users_test.go
@@ -4,11 +4,13 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
 	dockertest "gopkg.in/ory-am/dockertest.v2"
 
+	"github.com/garyburd/redigo/redis"
 	"github.com/mainflux/mainflux-auth-server/cache"
 	"github.com/mainflux/mainflux-auth-server/domain"
 	"github.com/mainflux/mainflux-auth-server/services"
@@ -45,13 +47,76 @@ func TestRegisterUser(t *testing.T) {
 
 	for _, c := range cases {
 		_, err := services.RegisterUser(c.username, c.password)
-
 		if err != nil {
-			auth := err.(*domain.AuthError)
-
+			auth := err.(*domain.ServiceError)
 			if auth.Code != c.code {
 				t.Errorf("expected %d got %d", c.code, auth.Code)
 			}
 		}
 	}
+}
+
+func TestAddUserKey(t *testing.T) {
+	uid, masterKey, err := fetchCredentials()
+	if err != nil {
+		t.Errorf("failed to retrieve created user data")
+	}
+
+	cases := []struct {
+		uid     string
+		key     string
+		payload domain.Payload
+		code    int
+	}{
+		{uid, masterKey, domain.Payload{}, 0},
+		{uid, "invalid-key", domain.Payload{}, http.StatusForbidden},
+		{"invalid-id", masterKey, domain.Payload{}, http.StatusNotFound},
+		{"invalid-id", "invalid-key", domain.Payload{}, http.StatusNotFound},
+	}
+
+	for _, c := range cases {
+		key, err := services.AddUserKey(c.uid, c.key, c.payload)
+		if err != nil {
+			auth := err.(*domain.ServiceError)
+			if auth.Code != c.code {
+				t.Errorf("expected %d got %d", c.code, auth.Code)
+			}
+			continue
+		}
+
+		if key == "" {
+			t.Errorf("expected key to be created")
+		}
+	}
+}
+
+//
+// NOTE: only one user will be created during the test container lifecycle
+//
+func fetchCredentials() (string, string, error) {
+	c := cache.Connection()
+	vals, err := c.Do("KEYS", "users:*")
+	if err != nil {
+		return "", "", err
+	}
+
+	cKeys, err := redis.Strings(vals, err)
+	if err != nil {
+		return "", "", err
+	}
+
+	cKey := cKeys[0]
+	id := strings.Split(cKey, ":")[1]
+
+	cVal, err := c.Do("HGET", cKey, "masterKey")
+	if err != nil {
+		return "", "", err
+	}
+
+	token, err := redis.String(cVal, err)
+	if err != nil {
+		return "", "", err
+	}
+
+	return id, token, nil
 }


### PR DESCRIPTION
Additional user keys will be created through the separate endpoint.
Besides providing a scopes specification, users are required to provide
their master key. During this iteration, all explicit type assertions on
redis responses are replaced with library helper functions.